### PR TITLE
Change 12-Hour Time Format to a 24-Hour Time Format.

### DIFF
--- a/src/views/TgBlog.vue
+++ b/src/views/TgBlog.vue
@@ -255,7 +255,7 @@ export default class TgBlog extends Vue
         {
             if (this.postsData) this.posts = this.postsData
             else this.posts = await (await fetch(this.purl)).json()
-            this.posts.forEach(it => it.date = moment(it.date).format('YYYY-MM-DD h:mm'))
+            this.posts.forEach(it => it.date = moment(it.date).format('YYYY-MM-DD H:mm'))
             this.posts.reverse()
             this.posts = this.posts.filter(it => it.type !== 'service')
             this.count = Math.min(this.count, this.posts.length)


### PR DESCRIPTION
Since the 12-hour time format is used and AM/PM is not displayed, there may be problems with articles on the same day, so it is recommended to change 12-hour time format to 24-hour time format.