### PR TITLE
[U] Update library sources from unpkg to jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ You can use it in plain HTML without a modern web build tool:
   <title>My Blog</title>
 
   <!-- Import Libraries -->
-  <script src="https://unpkg.com/vue@3"></script>
-  <script src="https://unpkg.com/tg-blog"></script>
-  <link rel="stylesheet" href="https://unpkg.com/tg-blog/dist/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tg-blog"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tg-blog/dist/style.css">
 
   <!-- Styles -->
   <style>
@@ -80,9 +80,9 @@ date: 2023-01-13
 {% raw %}
 
 <!-- Import Libraries -->
-<script src="https://unpkg.com/vue@3"></script>
-<script src="https://unpkg.com/tg-blog"></script>
-<link rel="stylesheet" href="https://unpkg.com/tg-blog/dist/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tg-blog"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tg-blog/dist/style.css">
 
 <!-- Styles & Patches -->
 <style>

--- a/demo.html
+++ b/demo.html
@@ -5,9 +5,9 @@
   <title>My Blog</title>
 
   <!-- Import Libraries -->
-  <script src="https://unpkg.com/vue@3"></script>
-  <script src="https://unpkg.com/tg-blog"></script>
-  <link rel="stylesheet" href="https://unpkg.com/tg-blog/dist/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tg-blog"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tg-blog/dist/style.css">
 
   <!-- Styles -->
   <style>

--- a/demo.local.html
+++ b/demo.local.html
@@ -5,7 +5,7 @@
   <title>My Blog</title>
 
   <!-- Import Libraries -->
-  <script src="https://unpkg.com/vue@3"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
   <script src="./dist/tg-blog.umd.js"></script>
   <link rel="stylesheet" href="./dist/style.css">
 


### PR DESCRIPTION
Hello, I noticed unpkg is having a lot of issues lately and the tg-blog libraries aren't being loaded properly
![image](https://github.com/user-attachments/assets/1bc83716-006f-4cdc-b5f4-8f6d82572764)

This PR replaces unpkg with jsDelivr which is much more reliable.
This issue is happening on a lot of repositories.
https://github.com/unpkg/unpkg/issues/412
https://github.com/unpkg/unpkg/issues/416

Please let me know if any modifications are needed.

An example using jsDelivr is at https://cvyl.me/life
https://github.com/cvyl/cvyl.github.io/blob/main/source/life/index.md